### PR TITLE
Added macos_x86 and macos_arm64 fields to download

### DIFF
--- a/template.json
+++ b/template.json
@@ -11,7 +11,10 @@
     "macos": "",
     "windows": ""
   },
-  "download": {},
+  "download": {
+    "macos_x86": "",
+    "macos_arm64": ""
+  },
   "tools": [],
   "linked": false
 }


### PR DESCRIPTION
Two optional fields are introduced within the Download field of `template.json` macos_x86 and macos_arm64