### PR TITLE
Create branch before updating data

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,8 @@ runs:
         git config --global user.name "${{ inputs.gh-name }}"
         git add data
         git commit -m "Updating release for ${{ env.NAME }}-${{ env.VERSION }}"
+        
+        git status
         (git push origin $BRANCH -f &> /dev/null) || (git push --set-upstream origin $BRANCH)
         gh pr create \
           --title "Release for ${{ env.NAME }}-${{ env.VERSION }}" \

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,8 @@ runs:
       run: |
         echo "NAME=${NAME:-${{ github.event.repository.name }}}" >> $GITHUB_ENV
         echo "VERSION=${VERSION:=${GITHUB_REF##*/}}" >> $GITHUB_ENV
-        echo "Stored $NAME and $VERSION"
+        echo "BRANCH=coolbot/update-$NAME-$VERSION" >> $GITHUB_ENV
+        echo "Stored $NAME and $VERSION, attempting to create branch $BRANCH"
 
     - name: "Ensures release is not linked"
       shell: bash
@@ -49,7 +50,6 @@ runs:
       run: |
         gh auth setup-git
         (git show-branch $BRANCH &>/dev/null) && (git checkout $BRANCH) || (git checkout -b $BRANCH)
-        git status
         echo "checked out"
         git reset --hard origin/main
         git status
@@ -60,7 +60,6 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
-        BRANCH: coolbot/update-${{ env.NAME }}-${{ env.VERSION }}
       run: |
         git config --global user.email "${{ inputs.gh-email }}"
         git config --global user.name "${{ inputs.gh-name }}"

--- a/action.yml
+++ b/action.yml
@@ -25,8 +25,6 @@ runs:
       shell: bash
       run: |
         echo "NAME=${NAME:-${{ github.event.repository.name }}}" >> $GITHUB_ENV
-        echo ${GITHUB_REF##*/}
-        echo $VERSION
         echo "VERSION=${VERSION:=${GITHUB_REF##*/}}" >> $GITHUB_ENV
         echo "Stored $NAME and $VERSION"
 
@@ -65,7 +63,7 @@ runs:
         git config --global user.name "${{ inputs.gh-name }}"
         git add data
         git commit -m "Updating release for ${{ env.NAME }}-${{ env.VERSION }}"
-        git push origin $BRANCH -f
+        (git push origin $BRANCH -f &> /dev/null) || (git push --set-upstream origin &BRANCH)
         gh pr create \
           --title "Release for ${{ env.NAME }}-${{ env.VERSION }}" \
           --body "Automated registry sync for ${{ env.NAME }} created by tag ${{ env.VERSION }}" \

--- a/action.yml
+++ b/action.yml
@@ -67,9 +67,13 @@ runs:
         git commit -m "Updating release for ${{ env.NAME }}-${{ env.VERSION }}"
         
         git status
-        (git push origin $BRANCH -f &> /dev/null) || (git push --set-upstream origin $BRANCH)
-        gh pr create \
-          --title "Release for ${{ env.NAME }}-${{ env.VERSION }}" \
-          --body "Automated registry sync for ${{ env.NAME }} created by tag ${{ env.VERSION }}" \
-          --reviewer swift-nav/devinfra
+        {
+          (git push --set-upstream origin $BRANCH &> /dev/null) &&
+          (gh pr create \
+            --title "Release for ${{ env.NAME }}-${{ env.VERSION }}" \
+            --body "Automated registry sync for ${{ env.NAME }} created by tag ${{ env.VERSION }}" \
+            --reviewer swift-nav/devinfra)
+        } || {
+          (git push origin $BRANCH -f)
+        }
           

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,8 @@ runs:
       shell: bash
       run: |
         echo "NAME=${NAME:-${{ github.event.repository.name }}}" >> $GITHUB_ENV
+        echo ${GITHUB_REF##*/}
+        echo $VERSION
         echo "VERSION=${VERSION:-${GITHUB_REF##*/}}" >> $GITHUB_ENV
         echo "Stored $NAME and $VERSION"
 
@@ -32,7 +34,7 @@ runs:
       shell: bash
       working-directory: data
       run: |
-        if cat ${NAME,,} | grep "\"version\":\"${{ env.VERSION }}\""; then
+        if cat ${NAME,,} | grep "\"version\":\"${VERSION}\""; then
           exit 1
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,9 @@ runs:
       run: |
         gh auth setup-git
         (git show-branch $BRANCH &>/dev/null) && (git checkout $BRANCH) || (git checkout -b $BRANCH)
-        git reset --hard main
+        git status
+        echo "checked out"
+        git reset --hard origin/main
         git status
         chmod +x ./gen
         ./gen

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
       run: |
         echo "NAME=${NAME:-${{ github.event.repository.name }}}" >> $GITHUB_ENV
         echo "VERSION=${VERSION:-${GITHUB_REF##*/}}" >> $GITHUB_ENV
-        echo "Stored ${{ env.NAME }} and ${{ env.VERSION }}"
+        echo "Stored $NAME and $VERSION"
 
     - name: "Ensures release is not linked"
       shell: bash
@@ -48,6 +48,8 @@ runs:
         GH_TOKEN: ${{ inputs.token }}
       run: |
         gh auth setup-git
+        (git show-branch $BRANCH &>/dev/null) && (git checkout $BRANCH) || (git checkout -b $BRANCH)
+        git reset --hard main
         chmod +x ./gen
         ./gen
 
@@ -57,11 +59,8 @@ runs:
         GH_TOKEN: ${{ inputs.token }}
         BRANCH: coolbot/update-${{ env.NAME }}-${{ env.VERSION }}
       run: |
-        rm ./gen
         git config --global user.email "${{ inputs.gh-email }}"
         git config --global user.name "${{ inputs.gh-name }}"
-        (git show-branch $BRANCH &>/dev/null) && (git checkout $BRANCH) || (git checkout -b $BRANCH)
-        git reset --hard main
         git add data
         git commit -m "Updating release for ${{ env.NAME }}-${{ env.VERSION }}"
         git push origin $BRANCH -f

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
         echo "NAME=${NAME:-${{ github.event.repository.name }}}" >> $GITHUB_ENV
         echo ${GITHUB_REF##*/}
         echo $VERSION
-        echo "VERSION=${VERSION:-${GITHUB_REF##*/}}" >> $GITHUB_ENV
+        echo "VERSION=${VERSION:=${GITHUB_REF##*/}}" >> $GITHUB_ENV
         echo "Stored $NAME and $VERSION"
 
     - name: "Ensures release is not linked"

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,7 @@ runs:
         gh auth setup-git
         (git show-branch $BRANCH &>/dev/null) && (git checkout $BRANCH) || (git checkout -b $BRANCH)
         git reset --hard main
+        git status
         chmod +x ./gen
         ./gen
 

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ runs:
         git config --global user.name "${{ inputs.gh-name }}"
         git add data
         git commit -m "Updating release for ${{ env.NAME }}-${{ env.VERSION }}"
-        (git push origin $BRANCH -f &> /dev/null) || (git push --set-upstream origin &BRANCH)
+        (git push origin $BRANCH -f &> /dev/null) || (git push --set-upstream origin $BRANCH)
         gh pr create \
           --title "Release for ${{ env.NAME }}-${{ env.VERSION }}" \
           --body "Automated registry sync for ${{ env.NAME }} created by tag ${{ env.VERSION }}" \


### PR DESCRIPTION
Handles two cases:
1) Branch exists, just need to reset + update branch.
2) Branch does not exist, create new branch.

Also changes checkout to before generating files (was bug since it just reset back to main and committed nothing)