### PR TITLE
Setup swift-cli-publisher to support s3 buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ Github account name
 
 + 'gh-email': 
 Github account email
+
++ 'aws-access-key-id':
+Optional: AWS access key ID used to provide access to the s3 bucket where the
+package is stored. Only required if using to publish binaries from an s3 bucket.
+
++ 'aws-secret-access-key':
+Optional: AWS secret access key used to provide access to the s3 bucket where the
+package is stored. Only required if using to publish binaries from an s3 bucket.
+
++ 'aws-access-region':
+Optional: AWS region to be used by the access key to log in.
+Only required if using to publish binaries from an s3 bucket.
 ```
 
 ### Release metadata
@@ -81,6 +93,16 @@ Most "required" are also optional i.e. you don't need all 3 platforms
 - `BASE_URL` corresponds to web download URL, providing this parameter opts for Web instead of GitHub
 - `PROJECT_SLUG` in the format "ORG/NAME", defaults to `swift-nav/$NAME`
 - `LINKED` (deprecated) not used
+
+If the package is going to be pulled in from an S3 bucket, the following must all be set
+
+- `TOOL_SPECIFIC_SHA` will generate a SHA for each tool, not just the archive if any
+   non-empty value is given.
+- `S3_REGION` the region of the bucket that contains the package
+- `S3_BUCKET` Name of the bucket
+- `S3_PREFIX` The common prefix for all the platforms. The tools will sync all files
+with the prefix `<S3_PREFIX><DL_*>`, Note the lack of a joining character between
+the two.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,16 +47,16 @@ Github account name
 Github account email
 
 + 'aws-access-key-id':
-Optional: AWS access key ID used to provide access to the s3 bucket where the
-package is stored. Only required if using to publish binaries from an s3 bucket.
+Optional: AWS access key ID used to provide access to the s3 bucket where the package is
+stored. Only required if using to publish binaries from an s3 bucket.
 
 + 'aws-secret-access-key':
-Optional: AWS secret access key used to provide access to the s3 bucket where the
-package is stored. Only required if using to publish binaries from an s3 bucket.
+Optional: AWS secret access key used to provide access to the s3 bucket where the package
+is stored. Only required if using to publish binaries from an s3 bucket.
 
 + 'aws-access-region':
-Optional: AWS region to be used by the access key to log in.
-Only required if using to publish binaries from an s3 bucket.
+Optional: AWS region to be used by the access key to log in. Only required if using to
+publish binaries from an s3 bucket.
 ```
 
 ### Release metadata

--- a/README.md
+++ b/README.md
@@ -100,9 +100,12 @@ If the package is going to be pulled in from an S3 bucket, the following must al
    non-empty value is given.
 - `S3_REGION` the region of the bucket that contains the package
 - `S3_BUCKET` Name of the bucket
-- `S3_PREFIX` The common prefix for all the platforms. The tools will sync all files
-with the prefix `<S3_PREFIX><DL_*>`, Note the lack of a joining character between
-the two.
+- `S3_PREFIX` A list of prefixes which are common across the platforms. The tools will sync all files
+with the prefix `<S3_PREFIX><DL_*>`, Note the lack of a joining character between the two. The prefixes
+must be separated by the <PREFIX_DELIMITER>.
+- `PREFIX_LIST_DELIMITER` Because s3 keys can be any valid UTF-8 string, there is an optional env var
+that can be set to specify what character splits the prefixes in the `S3_PREFIX` list. This var must
+only be one valid UTF-8 character. If let empty, the default value is `,`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ If the package is going to be pulled in from an S3 bucket, the following must al
 - `S3_BUCKET` Name of the bucket
 - `S3_PREFIX` A list of prefixes which are common across the platforms. The tools will sync all files
 with the prefix `<S3_PREFIX><DL_*>`, Note the lack of a joining character between the two. The prefixes
-must be separated by the <PREFIX_DELIMITER>.
+must be separated by the <PREFIX_LIST_DELIMITER>.
 - `PREFIX_LIST_DELIMITER` Because s3 keys can be any valid UTF-8 string, there is an optional env var
 that can be set to specify what character splits the prefixes in the `S3_PREFIX` list. This var must
-only be one valid UTF-8 character. If let empty, the default value is `,`.
+only be one valid UTF-8 character. If left empty, the default value is `,`.
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,13 @@ inputs:
   gh-email:
     description: "Github account email"
     required: true
+  aws-access-key-id:
+    description: "AWS access key ID"
+  aws-secret-access-key:
+    description: "Github account name"
+  aws-access-region:
+    description: "The AWS Region used by the access credentials"
+
 
 runs:
   using: composite
@@ -21,6 +28,13 @@ runs:
         token: ${{ inputs.token }}
         ref: main
 
+    - name: Set up credentials
+      if: ${{ inputs.aws-access-key-id != '' }}
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.secret-access-key }}
+        aws-region: ${{ inputs.aws-access-region }}
     - name: "Store name and version env vars"
       shell: bash
       run: |


### PR DESCRIPTION
This PR enables using the swift-cli-publisher to support the automated publishing of releases to the package manager for packages whose distribution method will be via downloading from an s3 bucket.

We should wait to merge this PR until https://github.com/swift-nav/swift-cli/pull/432 is merged into Main