### PR TITLE
bump aws action to latest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ runs:
 
     - name: Set up credentials
       if: ${{ inputs.aws-access-key-id != '' }}
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}


### PR DESCRIPTION
go to most recent version of aws-credential configurer. Resolves warning about node.js support deprecating.